### PR TITLE
fix: add missing content_scripts declaration to manifest.json

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,24 @@
   "background": {
     "service_worker": "service-worker.js"
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_end"
+    }
+  ],
   "action": {
     "default_popup": "popup.html"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["icons/*.png"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "host_permissions": [
+    "*://*/*"
+  ]
 }


### PR DESCRIPTION
The chat popup wasn't appearing because the manifest.json was missing the content_scripts section needed to inject content.js into web pages.

This fix adds:
- content_scripts configuration to inject content.js and styles.css
- web_accessible_resources for extension icons
- host_permissions for API access

Fixes #29

Generated with [Claude Code](https://claude.ai/code)