### PR TITLE
fix: Implement proper Anthropic API key testing in configuration

### DIFF
--- a/extension/options-new.js
+++ b/extension/options-new.js
@@ -1002,8 +1002,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         return true; // For now, assume it's valid
         
       case 'anthropic':
-        // Anthropic doesn't have a simple test endpoint, so we'll do a minimal completion
-        return true; // For now, assume it's valid
+        // Anthropic API test with minimal completion
+        testUrl = `${endpoint}/messages`;
+        headers['x-api-key'] = apiKey;
+        headers['anthropic-version'] = '2023-06-01';
+        headers['Content-Type'] = 'application/json';
+        break;
         
       case 'custom':
         // Try OpenAI-compatible endpoint
@@ -1035,11 +1039,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         signal: controller.signal
       };
       
-      // For Albert, use POST with minimal chat completion body
+      // For Albert and Anthropic, use POST with minimal chat completion body
       if (provider === 'albert') {
         fetchOptions.method = 'POST';
         fetchOptions.body = JSON.stringify({
           model: elements.model.value || 'albert-large',
+          messages: [
+            {
+              role: 'user',
+              content: 'Hello'
+            }
+          ],
+          max_tokens: 1
+        });
+      } else if (provider === 'anthropic') {
+        fetchOptions.method = 'POST';
+        fetchOptions.body = JSON.stringify({
+          model: elements.model.value || 'claude-3-haiku-20240307',
           messages: [
             {
               role: 'user',


### PR DESCRIPTION
Fixes #35

## Summary
- Replace dummy 'return true' with actual Anthropic API test request
- Add proper Anthropic API headers (x-api-key, anthropic-version)
- Add minimal completion request body for testing
- Ensures connection test matches actual chat functionality

## Issue Fixed
The connection test for Anthropic was not actually validating the API key, causing tests to pass while actual chat requests failed with "Invalid API key" error.

## Test Plan
- [ ] Configure invalid Anthropic API key - connection test should now fail
- [ ] Configure valid Anthropic API key - both test and chat should work
- [ ] Verify Albert functionality remains unchanged

Generated with [Claude Code](https://claude.ai/code)