### PR TITLE
fix: Add missing CORS header for Anthropic API calls

### DIFF
--- a/extension/options-new.js
+++ b/extension/options-new.js
@@ -1006,6 +1006,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         testUrl = `${endpoint}/messages`;
         headers['x-api-key'] = apiKey;
         headers['anthropic-version'] = '2023-06-01';
+        headers['anthropic-dangerous-direct-browser-access'] = 'true';
         headers['Content-Type'] = 'application/json';
         break;
         

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -948,6 +948,7 @@ Requirements:
         // Anthropic API format
         headers['x-api-key'] = apiKey;
         headers['anthropic-version'] = '2023-06-01';
+        headers['anthropic-dangerous-direct-browser-access'] = 'true';
         apiUrl = `${endpoint}/messages`;
         requestBody = {
           model: model,


### PR DESCRIPTION
Fixes #37

This PR resolves the Anthropic API installation and usage errors by adding the required CORS header for browser-based requests.

## Changes
- Added `anthropic-dangerous-direct-browser-access: 'true'` header to service-worker.js
- Added same header to options-new.js for API connection testing

## Fixes
- Eliminates CORS error during API calls
- Resolves 401 authentication errors during testing
- Enables proper Anthropic API key validation

Generated with [Claude Code](https://claude.ai/code)