### PR TITLE
Fix Anthropic API connection test with updated model name

### DIFF
--- a/extension/options-new.js
+++ b/extension/options-new.js
@@ -1056,7 +1056,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       } else if (provider === 'anthropic') {
         fetchOptions.method = 'POST';
         fetchOptions.body = JSON.stringify({
-          model: elements.model.value || 'claude-3-haiku-20240307',
+          model: elements.model.value || 'claude-3-haiku',
           messages: [
             {
               role: 'user',


### PR DESCRIPTION
Fixes #39 - Update fallback model from 'claude-3-haiku-20240307' to 'claude-3-haiku' in API connection testing to resolve '404 Not Found' errors causing 'API endpoint not found' message for valid Anthropic API keys.

Generated with [Claude Code](https://claude.ai/code)