### PR TITLE
Fix Chrome extension installation error - remove missing script reference

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -584,7 +584,6 @@
     </div>
   </div>
   
-  <script src="default-config.js"></script>
   <script src="crypto-utils.js"></script>
   <script src="options-new.js"></script>
 </body>


### PR DESCRIPTION
Fixes #39 - Resolves Chrome extension installation error by removing reference to missing default-config.js file

**Root Cause:** options.html was trying to load a script file that doesn't exist, causing Chrome to show "An unknown error occurred when fetching the script"

**Solution:** Removed the missing script reference from options.html. Service worker already handles this gracefully.

**Testing:** Extension should now install without errors in Chrome

Generated with [Claude Code](https://claude.ai/code)