### PR TITLE
Fix Anthropic API version and improve configuration access

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,5 +39,9 @@
   ],
   "host_permissions": [
     "*://*/*"
-  ]
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
 }

--- a/extension/options-new.js
+++ b/extension/options-new.js
@@ -1009,7 +1009,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Anthropic API test with minimal completion
         testUrl = `${endpoint}/messages`;
         headers['x-api-key'] = apiKey;
-        headers['anthropic-version'] = '2023-10-22';
+        headers['anthropic-version'] = '2023-06-01';
         headers['anthropic-dangerous-direct-browser-access'] = 'true';
         headers['Content-Type'] = 'application/json';
         break;

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -953,7 +953,7 @@ Requirements:
       case 'anthropic':
         // Anthropic API format
         headers['x-api-key'] = apiKey;
-        headers['anthropic-version'] = '2023-10-22';
+        headers['anthropic-version'] = '2023-06-01';
         headers['anthropic-dangerous-direct-browser-access'] = 'true';
         apiUrl = `${endpoint}/messages`;
         requestBody = {


### PR DESCRIPTION
Fixes two critical issues preventing MiCha extension usage:

## 🔧 Configuration Access Fixed
- Added `options_ui` declaration to manifest.json
- Users can now access configuration via multiple methods:
  - Settings gear icon in extension popup
  - Right-click extension icon → Options
  - "Advanced Settings" button when API key is configured

## 📡 Anthropic API Version Fixed
- Updated invalid version "2023-10-22" to correct "2023-06-01"
- Fixed in both service-worker.js and options-new.js
- Resolves "anthropic-version is not a valid version" error

Closes #50

Generated with [Claude Code](https://claude.ai/code)